### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setuptools.setup(
     author="Mateusz Korniak",    
     author_email="matkorpypiorg@ant.gliwice.pl",
     description="Interface to eSterownik.pl eCoal water boiler controller.",
+    license="GPLv3+",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/matkor/ecoaliface",


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.